### PR TITLE
Correct optic advantage text + correct typo

### DIFF
--- a/templates/optic.html
+++ b/templates/optic.html
@@ -18,7 +18,7 @@
     <li id="acceleration-optic"><strong>Accélération</strong> des délais d'encaissement.</li>
     <li id="simplification-optic"><strong>Prise en charge complète</strong> traitement des rejets et impayés, rapprochement bancaire, relance des crédits.</li>
     <li id="recoverate-optic"><strong>Récupération</strong> rapide de trésorerie.</li>
-    <li id="rationalization-optic"><strong>Rationnalisation</strong> du temps passé en back-office.</li>
+    <li id="rationalization-optic"><strong>Rationalisation</strong> du temps passé en back-office.</li>
     <li id="optimization-optic"><strong>Accompagnement d'un expert du tiers-payant</strong> avec des points réguliers pour vous informer de l'évolution de votre tiers-payant.</li>
   </ul>
 </section>

--- a/templates/optic.html
+++ b/templates/optic.html
@@ -14,9 +14,9 @@
   <h2>Les avantages de l'externalisation</h2>
   <ul>
     <li id="time-optic"><strong>Gain de temps</strong> moins d'administratif, plus de temps pour sa clientèle.</li>
-    <li id="economy-optic"><strong>Économie et gain de productivité.</strong></li>
+    <li id="economy-optic"><strong>Économie et gain de productivité</strong></li>
     <li id="acceleration-optic"><strong>Accélération</strong> des délais d'encaissement.</li>
-    <li id="simplification-optic"><strong>Prise en charge complète</strong> préparation télétransmission, traitement des rejets, rapprochement bancaire.</li>
+    <li id="simplification-optic"><strong>Prise en charge complète</strong> traitement des rejets et impayés, rapprochement bancaire, relance des crédits.</li>
     <li id="recoverate-optic"><strong>Récupération</strong> rapide de trésorerie.</li>
     <li id="rationalization-optic"><strong>Rationnalisation</strong> du temps passé en back-office.</li>
     <li id="optimization-optic"><strong>Accompagnement d'un expert du tiers-payant</strong> avec des points réguliers pour vous informer de l'évolution de votre tiers-payant.</li>


### PR DESCRIPTION
Suite au ticket https://github.com/Kozea/www-teepy/issues/50 : 

- j'ai corrigé le texte concernant "la prise en charge" (demande du ticket)
- et j'en ai profité pour supprimer un point inutile après "économie et gain de productivité"